### PR TITLE
Add "box" to the preview options in interfaces.json

### DIFF
--- a/schemas/custom-app/interfaces.schema.json
+++ b/schemas/custom-app/interfaces.schema.json
@@ -78,7 +78,7 @@
 					"properties": {
 						"type": {
 							"type": "string",
-							"enum": ["block", "circle", "text", "grid"]
+							"enum": ["block", "box", "circle", "text", "grid"]
 						},
 						"width": { "type": "number" },
 						"height": { "type": "number" }


### PR DESCRIPTION
Box is one of the preview types for a block inside interfaces.json. It's the same as "block" but it won't throw a warning about deprecation: https://github.com/vtex-apps/render-runtime/blob/2c7076c986baaf252c7ce2ba6b04949b55f67de3/react/components/Preview/index.tsx#L42

![image](https://github.com/user-attachments/assets/7bbdf8e8-896e-49f5-90aa-cf32ec39a9b6)
