### PR TITLE
ref: handle definition request

### DIFF
--- a/schemas/shared/block.schema.json
+++ b/schemas/shared/block.schema.json
@@ -1,6 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Block's id",
-  "description": "Block's id",
   "type": "string"
 }

--- a/server/src/handleDefinitionRequest.ts
+++ b/server/src/handleDefinitionRequest.ts
@@ -1,77 +1,143 @@
-import { readFileSync } from 'fs';
-import { DefinitionParams } from 'vscode-languageserver';
+import { DefinitionParams, LocationLink } from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
+import * as JSONC from 'jsonc-parser';
 import { BlocksHashMap } from './BlocksHashMap';
 import { getBlockPositionInText } from './utils/getBlockPositionInText';
 
-// Handles a request to provide the definition of a symbol at a given text document position.
-export const handleDefinitionRequest = (params: DefinitionParams, blocksHashMap: BlocksHashMap) => {
+/**
+ * Handles a request to provide the definition of a block reference at a given text document position.
+ * This allows users to navigate to the definition of a block by clicking on its reference.
+ */
+export const handleDefinitionRequest = (params: DefinitionParams, blocksHashMap: BlocksHashMap): LocationLink[] | undefined => {
 	const { textDocument, position } = params;
 
 	const filePath = URI.parse(textDocument.uri).fsPath;
 	const fileText = blocksHashMap.getFileContent(filePath);
+	if (!fileText) return undefined;
 
-	const lines = fileText.split(/\r?\n/);
-	const line = lines[position.line];
+	// Convert position to offset for JSONC scanner
+	const offset = getOffsetAtPosition(fileText, position);
 
-	if (!line) return undefined;
+	// Find the string token at the current position
+	const stringToken = findStringTokenAtOffset(fileText, offset);
+	if (!stringToken) return undefined;
 
-	const hoveredChar = line.charAt(position.character);
+	const { value: blockId, range } = stringToken;
+	console.log('blockId', blockId);
+	console.log('range', range);
 
-	let initialChar = hoveredChar;
-	let endChar = hoveredChar;
-	let matchStartsAt = position.character;
-	let matchEndsAt = position.character + 1;
+	// Check if this is a block reference (not a property name)
+	if (isPropertyName(fileText, range.start)) return undefined;
 
-	while (initialChar !== '"' || endChar !== '"') {
-		if (initialChar !== '"') matchStartsAt--;
-		if (endChar !== '"') matchEndsAt++;
-
-		if (matchStartsAt < 0) return undefined;
-		if (matchEndsAt > line.length) return undefined;
-
-		initialChar = line?.charAt(matchStartsAt);
-		endChar = line?.charAt(matchEndsAt);
-	}
-
-	matchStartsAt++;
-
-	const match = line.substring(matchStartsAt, matchEndsAt);
-	const matchIsADefinition = line.includes(`"${match}":`);
-
-	if (matchIsADefinition) return undefined;
-
+	// Try to find the definition of the block
 	try {
-		const definitionFilePath = blocksHashMap.getBlockFilePath(match);
-		const definitionFileContent = blocksHashMap.getFileContent(definitionFilePath);
-		const definitionPosition = getBlockPositionInText(match, definitionFileContent);
+		const definitionFilePath = blocksHashMap.getBlockFilePath(blockId);
+		if (!definitionFilePath) return undefined;
 
+		const definitionFileContent = blocksHashMap.getFileContent(definitionFilePath);
+		if (!definitionFileContent) return undefined;
+
+		const definitionPosition = getBlockPositionInText(blockId, definitionFileContent);
 		if (!definitionPosition) return undefined;
 
-		const {
-			start: { line: startLine, character: startCharacter },
-			end: { line: endLine, character: endCharacter }
-		} = definitionPosition;
+		// Convert the token range to document positions for proper highlighting
+		const originRange = {
+			start: positionAt(fileText, range.start + 1), // +1 to skip the opening quote
+			end: positionAt(fileText, range.end - 1)      // -1 to skip the closing quote
+		};
 
-		return [
-			{
-				uri: textDocument.uri,
-				originSelectionRange: {
-					start: { line: position.line, character: matchStartsAt },
-					end: { line: position.line, character: matchEndsAt }
-				},
-				targetUri: URI.file(definitionFilePath).toString(),
-				targetSelectionRange: {
-					start: { line: startLine, character: startCharacter },
-					end: { line: endLine, character: endCharacter }
-				},
-				targetRange: {
-					start: { line: startLine, character: startCharacter },
-					end: { line: endLine, character: endCharacter }
-				}
-			}
-		];
+		// Return a LocationLink which includes originSelectionRange for proper highlighting
+		return [{
+			originSelectionRange: originRange,
+			targetUri: URI.file(definitionFilePath).toString(),
+			targetRange: definitionPosition,
+			targetSelectionRange: definitionPosition
+		}];
 	} catch (error) {
-		return;
+		console.error(`Error finding definition for block "${blockId}":`, error);
+		return undefined;
 	}
 };
+
+/**
+ * Calculates the character offset at a given position in the document
+ */
+function getOffsetAtPosition(text: string, position: { line: number; character: number }): number {
+	const lines = text.split(/\r?\n/);
+	let offset = 0;
+
+	for (let i = 0; i < position.line; i++) {
+		offset += lines[i].length + 1; // +1 for the newline character
+	}
+
+	return offset + position.character;
+}
+
+/**
+ * Converts an offset to a Position object
+ */
+function positionAt(text: string, offset: number): { line: number; character: number } {
+	const lines = text.split(/\r?\n/);
+	let currentOffset = 0;
+	let lineNumber = 0;
+
+	for (const line of lines) {
+		const lineLength = line.length + 1; // +1 for the newline character
+		if (currentOffset + lineLength > offset) {
+			return {
+				line: lineNumber,
+				character: offset - currentOffset
+			};
+		}
+		currentOffset += lineLength;
+		lineNumber++;
+	}
+
+	// Fallback for end of document
+	return {
+		line: lines.length - 1,
+		character: lines[lines.length - 1].length
+	};
+}
+
+/**
+ * Finds a string token at the given offset in the text
+ */
+function findStringTokenAtOffset(text: string, offset: number): { value: string; range: { start: number; end: number } } | undefined {
+	const scanner = JSONC.createScanner(text, true);
+	let token = scanner.scan();
+
+	while (token !== JSONC.SyntaxKind.EOF) {
+		if (token === JSONC.SyntaxKind.StringLiteral) {
+			const start = scanner.getTokenOffset();
+			const length = scanner.getTokenLength();
+			const end = start + length;
+
+			// Check if cursor is inside this string token
+			if (offset >= start && offset <= end) {
+				return {
+					value: scanner.getTokenValue(),
+					range: { start, end }
+				};
+			}
+		}
+		token = scanner.scan();
+	}
+
+	return undefined;
+}
+
+/**
+ * Checks if a string at the given position is a property name (key) in JSON
+ */
+function isPropertyName(text: string, position: number): boolean {
+	const scanner = JSONC.createScanner(text, true);
+	scanner.setPosition(position);
+
+	// Scan the string token
+	scanner.scan();
+
+	// Check if the next token is a colon
+	const nextToken = scanner.scan();
+	return nextToken === JSONC.SyntaxKind.ColonToken;
+}

--- a/server/src/handleDefinitionRequest.ts
+++ b/server/src/handleDefinitionRequest.ts
@@ -23,8 +23,6 @@ export const handleDefinitionRequest = (params: DefinitionParams, blocksHashMap:
 	if (!stringToken) return undefined;
 
 	const { value: blockId, range } = stringToken;
-	console.log('blockId', blockId);
-	console.log('range', range);
 
 	// Check if this is a block reference (not a property name)
 	if (isPropertyName(fileText, range.start)) return undefined;


### PR DESCRIPTION
# PR Description: Improve Block Definition Navigation with JSONC Parser

## Overview
This PR enhances the "Go to Definition" functionality for VTEX IO blocks by refactoring the `handleDefinitionRequest` function to use the JSONC parser. The implementation now properly identifies block references in JSON/JSONC files and provides accurate navigation to their definitions.

## Key Improvements
- Replaced manual string parsing with proper JSONC token scanning
- Added helper functions for better code organization and readability
- Improved error handling with early returns and better error logging
- Fixed issues with string token detection and position calculation
- Removed debug console logs that were cluttering the output

## Technical Details
The implementation now:
1. Properly identifies string tokens in JSON/JSONC files
2. Distinguishes between property names and values
3. Accurately calculates positions for highlighting
4. Provides better error handling and logging

## Testing
The changes have been tested with various JSON files containing block references, including:
- Block references in property values
- Block references in arrays
- Nested block structures
- Files with JSONC comments

All tests confirm that the "Go to Definition" functionality works correctly, taking users to the appropriate block definition when clicking on a block reference.

## Related Issues
Fixes the issue where hovering over a block reference would not highlight the entire block ID.
