### PR TITLE
fix(condition-layout): show condition parameters for every item of the array

### DIFF
--- a/schemas/apps/condition-layout.product.schema.json
+++ b/schemas/apps/condition-layout.product.schema.json
@@ -14,24 +14,22 @@
 			"properties": {
 				"conditions": {
 					"type": "array",
-					"items": [
-						{
-							"type": "object",
-							"properties": {
-								"subject": {
-									"type": "string"
-								},
-								"arguments": {
-									"type": "object",
-									"properties": {
-										"id": {
-											"type": "string"
-										}
+					"items": {
+						"type": "object",
+						"properties": {
+							"subject": {
+								"type": "string"
+							},
+							"arguments": {
+								"type": "object",
+								"properties": {
+									"id": {
+										"type": "string"
 									}
 								}
 							}
 						}
-					]
+					}
 				},
 				"Then": { "$ref": "./../shared/block.schema.json" },
 				"Else": { "$ref": "./../shared/block.schema.json" }

--- a/schemas/apps/condition-layout/condition-layout.binding.schema.json
+++ b/schemas/apps/condition-layout/condition-layout.binding.schema.json
@@ -13,32 +13,30 @@
 				"conditions": {
 					"type": "array",
 					"markdownDescription": "array\n\nList of desired conditions.",
-					"items": [
-						{
-							"type": "object",
-							"properties": {
-								"subject": {
-									"type": "string",
-									"properties": {
-										"id": {
-											"type": "string"
-										}
-									},
-									"markdownDescription": "string\n\nDefines, according to the product context where the block in declared in, which data is needed from the UI to validate the value chosen in the object prop. Check below the possible values for this prop.\n\n**Subject** | **Arguments**\n\nbindingId | `{ id: string }`",
-									"oneOf": [{ "const": "bindingId" }]
+					"items": {
+						"type": "object",
+						"properties": {
+							"subject": {
+								"type": "string",
+								"properties": {
+									"id": {
+										"type": "string"
+									}
 								},
-								"arguments": {
-									"type": "object",
-									"markdownDescription": "object\n\nDefines, according to the product context where the block in declared in, which data is needed from the UI to validate the value chosen in the object prop. Check below the possible values for this prop.\n\n**Subject** | **Arguments**\n\nbindingId | `{ id: string }`"
-								},
-								"toBe": {
-									"type": "boolean",
-									"markdownDescription": "boolean\n\nWhether the data fetched in the subject prop must met the predefined conditions to render the new layout (true) or not (false).",
-									"default": false
-								}
+								"markdownDescription": "string\n\nDefines, according to the product context where the block in declared in, which data is needed from the UI to validate the value chosen in the object prop. Check below the possible values for this prop.\n\n**Subject** | **Arguments**\n\nbindingId | `{ id: string }`",
+								"oneOf": [{ "const": "bindingId" }]
+							},
+							"arguments": {
+								"type": "object",
+								"markdownDescription": "object\n\nDefines, according to the product context where the block in declared in, which data is needed from the UI to validate the value chosen in the object prop. Check below the possible values for this prop.\n\n**Subject** | **Arguments**\n\nbindingId | `{ id: string }`"
+							},
+							"toBe": {
+								"type": "boolean",
+								"markdownDescription": "boolean\n\nWhether the data fetched in the subject prop must met the predefined conditions to render the new layout (true) or not (false).",
+								"default": false
 							}
 						}
-					]
+					}
 				},
 				"matchType": {
 					"type": "string",

--- a/schemas/apps/condition-layout/condition-layout.product.schema.json
+++ b/schemas/apps/condition-layout/condition-layout.product.schema.json
@@ -11,41 +11,39 @@
 			"properties": {
 				"conditions": {
 					"type": "array",
-					"items": [
-						{
-							"type": "object",
-							"properties": {
-								"subject": {
-									"type": "string",
-									"oneOf": [
-										{ "const": "productId" },
-										{ "const": "categoryId" },
-										{ "const": "brandId" },
-										{ "const": "selectedItemId" },
-										{ "const": "productClusters" },
-										{ "const": "categoryTree" },
-										{ "const": "specificationProperties" },
-										{ "const": "areAllVariationsSelected" },
-										{ "const": "isProductAvailable" },
-										{ "const": "hasMoreSellersThan" }
-									]
-								},
-								"arguments": {
-									"type": "object",
-									"properties": {
-										"id": {
-											"type": "string"
-										}
+					"items": {
+						"type": "object",
+						"properties": {
+							"subject": {
+								"type": "string",
+								"oneOf": [
+									{ "const": "productId" },
+									{ "const": "categoryId" },
+									{ "const": "brandId" },
+									{ "const": "selectedItemId" },
+									{ "const": "productClusters" },
+									{ "const": "categoryTree" },
+									{ "const": "specificationProperties" },
+									{ "const": "areAllVariationsSelected" },
+									{ "const": "isProductAvailable" },
+									{ "const": "hasMoreSellersThan" }
+								]
+							},
+							"arguments": {
+								"type": "object",
+								"properties": {
+									"id": {
+										"type": "string"
 									}
-								},
-								"toBe": {
-									"type": "boolean",
-									"markdownDescription": "boolean\n\nWhether the data fetched in the subject prop must met the predefined conditions to render the new layout (true) or not (false).",
-									"default": false
 								}
+							},
+							"toBe": {
+								"type": "boolean",
+								"markdownDescription": "boolean\n\nWhether the data fetched in the subject prop must met the predefined conditions to render the new layout (true) or not (false).",
+								"default": false
 							}
 						}
-					]
+					}
 				},
 				"matchType": {
 					"type": "string",


### PR DESCRIPTION
Currently, whenever we declare conditions in the condition-layout block, only the first one shows the available parameters (subject, arguments, and so on). In the schema, the brackets in `items` shouldn't be necessary since the `type` already specifies it's an array.

| Before | After |
|---|---|
| ![image](https://github.com/user-attachments/assets/383c5ac2-f454-4eb8-a33a-7953b86c1e87) | ![image](https://github.com/user-attachments/assets/90dca7cd-35a3-4a3b-88a6-7258b8c8ac93) |